### PR TITLE
make sure the etag header is a correct md5 string

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function createMiddleware(path, options) {
     , headers =
       { 'Content-Type': 'text/plain'
       , 'Content-Length': txt.length
-      , 'ETag': '"' + crypto.createHash('md5').update(txt) + '"'
+      , 'ETag': '"' + crypto.createHash('md5').update(txt).digest('hex') + '"'
       , 'Cache-Control': 'public, max-age=' + (maxAge / 1000)
       }
 

--- a/test/robots.test.js
+++ b/test/robots.test.js
@@ -52,7 +52,6 @@ describe('robots.txt middleware', function () {
       createMiddleware(__dirname + '/fixtures/robots.txt')(req, res)
     })
 
-
     it('should set the "Content-Length" header equal to the file size in bytes', function (done) {
       var req = { url: '/robots.txt' }
         , res =
@@ -66,6 +65,17 @@ describe('robots.txt middleware', function () {
       createMiddleware(__dirname + '/fixtures/robots.txt')(req, res)
     })
 
+    it('should set the "ETag" header to the md5 of the robots.txt', function (done) {
+      var req = { url: '/robots.txt' }
+        , res =
+          { writeHead: function (status, headers) {
+              assert.equal('"7d7266f29c4a562082cd27ebdea6a91b"', headers.ETag)
+              done()
+            }
+          , end: function () {}
+          }
+      createMiddleware(__dirname + '/fixtures/robots.txt')(req, res)
+    })
   })
 
 })


### PR DESCRIPTION
Previously the ETag header was being saved as “[object Object]” as the md5 wasn’t outputted as a string. This was causing the robots.txt files to be cached too long and updates weren't visible immediately.
