### PR TITLE
add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "robots.txt",
   "version": "1.1.0",
   "description": "robots.txt middleware for express/connect to server up your robots.txt",
+  repository: "https://github.com/tomgco/robots.txt",
   "main": "index.js",
   "publishConfig": {
     "registry": "http://registry.npmjs.org/"


### PR DESCRIPTION
Hi @tomgco. I see this repo has been quiet for a number of years, but figured I'd give this PR a try.

This adds the `repository` value to `package.json`, so it will be easier for users to discover the source code for the module when browsing the npm website.